### PR TITLE
Readme updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 .DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -26,15 +26,117 @@ You can restrict packages by version range, and for blacklisted items, you can d
 
 ## Getting Started
 
+### Add sbt plugin
+
 First, add the following dependency to your project:
 
 ```
 addSbtPlugin("io.verizon.build" % "sbt-blockade" % "0.2.+")
 ```
 
-Both a whitelist and blacklist may be used. Ivy version ranges are specified in accordance with [the Ivy version matcher docs](http://ant.apache.org/ivy/history/2.1.0/settings/version-matchers.html).
+### Add build settings
+
+The most important setting is the `blockadeUris` sequence:
+
+```
+blockadeUris := Seq(new java.net.URI(s"file:///${baseDirectory.value}/blockade.json"))
+```
+
+In the above example, *sbt-blockade* will use `blockade.json` from the root of your project directory tree to define your restrictions.
+Depending on your organizational needs, this will more likely be a shared location accessible via http.
+
+Note that by default sbt-blockade will NOT fail if it encounters a `java.net.UnknownHostException`.
+This allows local compiles to succeed even if the `blockade.json` file is not accessible at all times to the developer's environment (wifi down, vpn down, etc).
+
+### Using sbt-blockade
+
+Once you defined your `blockade.json` as described [below](#specifying-dependency-restrictions), you can have your dependencies validated by running the `blockade` sbt task.
+
+Ideally, you will want to make `compile` depend on `blockade` like the following shows.
+
+```
+compile in Compile <<= (compile in Compile).dependsOn(blockade)
+```
+
+### sbt-blockade results
+
+sbt-blockade will first check your direct dependencies.
+Any direct dependencies in violation of your `blockade.json` will case a build **error** when `blockade` is run.
+For instance, if scalaz stream version `7.1.a` is the latest version allowed, trying to depend on `0.8.6` will produce an error:
+
+```
+[warn] [test-proj] The following dependencies were caught in the blockade: 
+[warn] 	Restricted: org.scalaz.stream:scalaz-stream:0.8.6. Module within the exclusion range ']0.7.3a,)' and expires/expired at 2015-07-29 12:00:00.
+java.lang.RuntimeException: One or more of the specified immediate dependencies are restricted.
+	at scala.sys.package$.error(package.scala:27)
+	at verizon.build.BlockadePlugin$$anonfun$settings$6.apply(plugin.scala:111)
+	at verizon.build.BlockadePlugin$$anonfun$settings$6.apply(plugin.scala:88)
+	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
+	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
+	at sbt.std.Transform$$anon$4.work(System.scala:63)
+	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
+	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
+	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
+	at sbt.Execute.work(Execute.scala:235)
+	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
+	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
+	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
+	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
+	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
+	at java.lang.Thread.run(Thread.java:745)
+[error] (*:blockade) One or more of the specified immediate dependencies are restricted.
+[error] Total time: 5 s, completed Apr 14, 2017 4:05:46 PM
+```
+
+Secondly, sbt-blockade will check your transitive dependencies.
+If you instead have scalaz stream `0.8.6` as an _indirect_ dependency (say via http4s), you will get a **warning** and not an error:
+
+```
+[info] [test-proj] All direct dependencies are within current restrictions.
+[warn] [test-proj]
+[warn] com.joescii:test-proj:0.0.1-SNAPSHOT has a restricted transitive dependency: org.scalaz.stream:scalaz-stream:0.8.6
+[warn]   Module within the exclusion range ']0.7.3a,)' and expires/expired at 2015-07-29 12:00:00.
+[warn] 
+[warn] Here is the dependency chain:
+[warn]   com.joescii:test-proj:0.0.1-SNAPSHOT
+[warn]     org.http4s:http4s-dsl:0.15.8
+[warn]       org.http4s:http4s-core:0.15.8
+[warn]         org.scalaz.stream:scalaz-stream:0.8.6
+[warn] 
+[info] Compiling 9 Scala sources to /Users/joescii/code/test-proj/target/scala-2.11/classes...
+[success] Total time: 32 s, completed Apr 14, 2017 4:10:12 PM
+```
+
+Finally, if you have a direct dependency which is blacklisted with a future expiration date, you will get a build **warning**:
+
+```
+[warn] [test-proj] The following dependencies were caught in the blockade: 
+[warn] 	Deprecated: org.scalaz.stream:scalaz-stream:0.8.6. Module within the exclusion range ']0.7.3a,)' and expires/expired at 2017-07-29 12:00:00.
+[warn] [test-proj]
+[warn] com.joescii:test-proj:0.0.1-SNAPSHOT has a restricted transitive dependency: org.scalaz.stream:scalaz-stream:0.8.6
+[warn]   Module within the exclusion range ']0.7.3a,)' and expires/expired at 2017-07-29 12:00:00.
+[warn] 
+[warn] Here is the dependency chain:
+[warn]   com.joescii:test-proj:0.0.1-SNAPSHOT
+[warn]     intelmedia.ws.common_akka23:s2s:15.0.230
+[warn]       oncue.monitoring:core:1.0.9
+[warn]         oncue.knobs:core:3.9.16
+[warn]           org.scalaz.stream:scalaz-stream:0.8.6
+[warn] 
+[info] Compiling 9 Scala sources to /Users/joescii/code/test-proj/target/scala-2.11/classes...
+[success] Total time: 13 s, completed Apr 14, 2017 4:18:14 PM
+```
+
+Note that in both cases where a warning is raised, the build isn't failed and `compile` (etc) will run as usual.
 
 ### Specifying dependency restrictions
+
+Both a whitelist and blacklist may be used. 
+Ivy version ranges are specified in accordance with [the Ivy version matcher docs](http://ant.apache.org/ivy/history/2.1.0/settings/version-matchers.html).
 
 Dependency restrictions are specified using a JSON object containing a (possibly empty) array of blacklisted items and a (possibly empty) array of whitelisted items. Here's an example:
 
@@ -45,7 +147,7 @@ Dependency restrictions are specified using a JSON object containing a (possibly
       "organization": "commons-codec",
       "name": "commons-codec",
       "range": "[2.0,3.0["
-    },
+    }
   ],
   "blacklist": [
     {

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ compile in Compile <<= (compile in Compile).dependsOn(blockade)
 
 sbt-blockade will first check your direct dependencies.
 Any direct dependencies in violation of your `blockade.json` will case a build **error** when `blockade` is run.
-For instance, if scalaz stream version `7.1.a` is the latest version allowed, trying to depend on `0.8.6` will produce an error:
+For instance, if scalaz stream version `7.3.a` is the latest version allowed, trying to depend on `0.8.6` will produce an error:
 
 ```
 [warn] [test-proj] The following dependencies were caught in the blockade: 


### PR DESCRIPTION
Added:
* Details on configuring `blockadeUris`, including how `java.net.UnknownHostException` gets ignored
* Details on using the `blockade` task, with tip to make `compile` depend on it.
* Examples of running `blockade` with a block direct dependency, indirect dependency, and a not-yet-expired direct dependency