### PR TITLE
Add blockadeFailTransitive which gives ability to cause errors on tra…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 }
 ```
 
-You can specify whitelisted packages, or blacklisted packages -- or both (see the section *Specifying dependency restrictions* for more info). 
+You can specify whitelisted packages, or blacklisted packages -- or both (see the section *Specifying dependency restrictions* for more info).
 
 You can restrict packages by version range, and for blacklisted items, you can define a "probationary"/"warning" period that expires after a particular expiry date.
 
@@ -65,7 +65,7 @@ Any direct dependencies in violation of your `blockade.json` will case a build *
 For instance, if scalaz stream version `7.3.a` is the latest version allowed, trying to depend on `0.8.6` will produce an error:
 
 ```
-[warn] [test-proj] The following dependencies were caught in the blockade: 
+[warn] [test-proj] The following dependencies were caught in the blockade:
 [warn] 	Restricted: org.scalaz.stream:scalaz-stream:0.8.6. Module within the exclusion range ']0.7.3a,)' and expires/expired at 2015-07-29 12:00:00.
 java.lang.RuntimeException: One or more of the specified immediate dependencies are restricted.
 	at scala.sys.package$.error(package.scala:27)
@@ -92,7 +92,7 @@ java.lang.RuntimeException: One or more of the specified immediate dependencies 
 [error] Total time: 5 s, completed Apr 14, 2017 4:05:46 PM
 ```
 
-Secondly, sbt-blockade will check your transitive dependencies.
+sbt-blockade will also check your transitive dependencies.
 If you instead have scalaz stream `0.8.6` as an _indirect_ dependency (say via http4s), you will get a **warning** and not an error:
 
 ```
@@ -100,33 +100,70 @@ If you instead have scalaz stream `0.8.6` as an _indirect_ dependency (say via h
 [warn] [test-proj]
 [warn] com.joescii:test-proj:0.0.1-SNAPSHOT has a restricted transitive dependency: org.scalaz.stream:scalaz-stream:0.8.6
 [warn]   Module within the exclusion range ']0.7.3a,)' and expires/expired at 2015-07-29 12:00:00.
-[warn] 
+[warn]
 [warn] Here is the dependency chain:
 [warn]   com.joescii:test-proj:0.0.1-SNAPSHOT
 [warn]     org.http4s:http4s-dsl:0.15.8
 [warn]       org.http4s:http4s-core:0.15.8
 [warn]         org.scalaz.stream:scalaz-stream:0.8.6
-[warn] 
+[warn]
 [info] Compiling 9 Scala sources to /Users/joescii/code/test-proj/target/scala-2.11/classes...
 [success] Total time: 32 s, completed Apr 14, 2017 4:10:12 PM
+```
+
+However, if you have `blockadeFailTransitive := true` then transitive dependency violation warnings become errors.
+
+```
+[info] [warn] [transitive-restricted-dependencies-failure]
+[info] [warn] default:transitive-restricted-dependencies-failure:0.1-SNAPSHOT has a restricted transitive dependency: com.chuusai:shapeless:2.3.1
+[info] [warn]   Module within the exclusion range '[1.0,4.0]' and expires/expired at 2012-06-12 15:36:31.
+[info] [warn]
+[info] [warn] Here is the dependency chain:
+[info] [warn]   default:transitive-restricted-dependencies-failure:0.1-SNAPSHOT
+[info] [warn]     org.scodec:scodec-core:1.10.0
+[info] [warn]       com.chuusai:shapeless:2.3.1
+[info] [warn]
+[info] java.lang.RuntimeException: One or more transitive dependencies are restricted.
+[info] 	at scala.sys.package$.error(package.scala:27)
+[info] 	at verizon.build.BlockadePlugin$$anonfun$settings$6.apply(plugin.scala:123)
+[info] 	at verizon.build.BlockadePlugin$$anonfun$settings$6.apply(plugin.scala:90)
+[info] 	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
+[info] 	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
+[info] 	at sbt.std.Transform$$anon$4.work(System.scala:63)
+[info] 	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
+[info] 	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
+[info] 	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
+[info] 	at sbt.Execute.work(Execute.scala:237)
+[info] 	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
+[info] 	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
+[info] 	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
+[info] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
+[info] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+[info] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+[info] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+[info] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
+[info] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
+[info] 	at java.lang.Thread.run(Thread.java:745)
+[info] [error] (*:blockade) One or more transitive dependencies are restricted.
+[info] [error] Total time: 0 s, completed May 17, 2017 1:56:05 PM
 ```
 
 Finally, if you have a direct dependency which is blacklisted with a future expiration date, you will get a build **warning**:
 
 ```
-[warn] [test-proj] The following dependencies were caught in the blockade: 
+[warn] [test-proj] The following dependencies were caught in the blockade:
 [warn] 	Deprecated: org.scalaz.stream:scalaz-stream:0.8.6. Module within the exclusion range ']0.7.3a,)' and expires/expired at 2017-07-29 12:00:00.
 [warn] [test-proj]
 [warn] com.joescii:test-proj:0.0.1-SNAPSHOT has a restricted transitive dependency: org.scalaz.stream:scalaz-stream:0.8.6
 [warn]   Module within the exclusion range ']0.7.3a,)' and expires/expired at 2017-07-29 12:00:00.
-[warn] 
+[warn]
 [warn] Here is the dependency chain:
 [warn]   com.joescii:test-proj:0.0.1-SNAPSHOT
 [warn]     intelmedia.ws.common_akka23:s2s:15.0.230
 [warn]       oncue.monitoring:core:1.0.9
 [warn]         oncue.knobs:core:3.9.16
 [warn]           org.scalaz.stream:scalaz-stream:0.8.6
-[warn] 
+[warn]
 [info] Compiling 9 Scala sources to /Users/joescii/code/test-proj/target/scala-2.11/classes...
 [success] Total time: 13 s, completed Apr 14, 2017 4:18:14 PM
 ```
@@ -135,7 +172,7 @@ Note that in both cases where a warning is raised, the build isn't failed and `c
 
 ### Specifying dependency restrictions
 
-Both a whitelist and blacklist may be used. 
+Both a whitelist and blacklist may be used.
 Ivy version ranges are specified in accordance with [the Ivy version matcher docs](http://ant.apache.org/ivy/history/2.1.0/settings/version-matchers.html).
 
 Dependency restrictions are specified using a JSON object containing a (possibly empty) array of blacklisted items and a (possibly empty) array of whitelisted items. Here's an example:

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/blockade.json
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/blockade.json
@@ -5,6 +5,12 @@
       "name": "shapeless",
       "range": "[1.0,4.0]",
       "expiry": "2012-06-12 15:36:31"
+    },
+    {
+      "organization": "io.argonaut",
+      "name": "argonaut",
+      "range": "[6.0,7.0]",
+      "expiry": "2012-06-12 15:36:31"
     }
   ]
 }

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/build.sbt
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/build.sbt
@@ -1,0 +1,13 @@
+
+import verizon.build._
+
+scalaVersion := "2.10.4"
+
+libraryDependencies ++= List(
+  "org.scodec" %% "scodec-core"   % "1.10.0",
+  "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M5"
+)
+
+blockadeUris := Seq(new java.net.URI(s"file:///${baseDirectory.value}/blockade.json"))
+
+blockadeFailTransitive := true

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/project/plugins.sbt
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("io.verizon.build" % "sbt-blockade" % pluginVersion)
+}

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/src/main/scala/main.scala
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/src/main/scala/main.scala
@@ -1,0 +1,7 @@
+package foo
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("done.")
+  }
+}

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/test
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/test
@@ -1,0 +1,1 @@
+-> blockade

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/blockade.json
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/blockade.json
@@ -1,0 +1,16 @@
+{
+  "blacklist": [
+    {
+      "organization": "com.chuusai",
+      "name": "shapeless",
+      "range": "[1.0,4.0]",
+      "expiry": "3012-06-12 15:36:31"
+    },
+    {
+      "organization": "io.argonaut",
+      "name": "argonaut",
+      "range": "[6.0,7.0]",
+      "expiry": "3012-06-12 15:36:31"
+    }
+  ]
+}

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/build.sbt
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/build.sbt
@@ -1,0 +1,13 @@
+
+import verizon.build._
+
+scalaVersion := "2.10.4"
+
+libraryDependencies ++= List(
+  "org.scodec" %% "scodec-core"   % "1.10.0",
+  "com.github.alexarchambault" %% "argonaut-shapeless_6.2" % "1.2.0-M5"
+)
+
+blockadeUris := Seq(new java.net.URI(s"file:///${baseDirectory.value}/blockade.json"))
+
+blockadeFailTransitive := true

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/project/plugins.sbt
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("io.verizon.build" % "sbt-blockade" % pluginVersion)
+}

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/src/main/scala/main.scala
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/src/main/scala/main.scala
@@ -1,0 +1,7 @@
+package foo
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("done.")
+  }
+}

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/test
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/test
@@ -1,0 +1,1 @@
+> blockade

--- a/src/test/scala/Fixtures.scala
+++ b/src/test/scala/Fixtures.scala
@@ -25,6 +25,7 @@ trait Fixtures extends DependencyBuilders {
 
   val `toplevel-has-direct-dep-on-scalaz` = "org.foo" %% "has-direct-dep-on-scalaz" % "1.2.4"
   val `toplevel-has-trans-dep-on-shapeless` = "org.foo" %% "has-trans-dep-on-shapeless" % "1.2.3"
+  val `toplevel-has-trans-dep-on-scalaz` = "org.foo" %% "has-trans-dep-on-scalaz" % "1.2.5"
   val `doobie-core-0.2.3` = "org.tpolecat" %% "doobie-core" % "0.2.3"
   val `scalaz-core-7.1.4` = "org.scalaz" %% "scalaz-core" % "7.1.4"
   val `scalaz-effect-7.1.4` = "org.scalaz" %% "scalaz-effect" % "7.1.4"
@@ -33,6 +34,7 @@ trait Fixtures extends DependencyBuilders {
 
   val m0HasScalazDep = Module(toModuleId(`toplevel-has-direct-dep-on-scalaz`))
   val m0HasShapelessTransDep = Module(toModuleId(`toplevel-has-trans-dep-on-shapeless`))
+  val m0HasScalazTransDep = Module(toModuleId(`toplevel-has-trans-dep-on-scalaz`))
   val m1 = Module(toModuleId(`doobie-core-0.2.3`))
   val m2 = Module(toModuleId(`scalaz-core-7.1.4`))
   val m3 = Module(
@@ -42,9 +44,10 @@ trait Fixtures extends DependencyBuilders {
   val m4 = Module(toModuleId(`scalaz-stream-0.8`))
   val m5 = Module(toModuleId(`shapeless-2.2.5`))
   val graphWithNestedShapeless = ModuleGraph(
-    nodes = Seq(m5, m3, m4, m0HasShapelessTransDep, m1, m2, m0HasScalazDep),
+    nodes = Seq(m5, m3, m4, m0HasShapelessTransDep, m0HasScalazTransDep, m1, m2, m0HasScalazDep),
     edges = Seq(
       m0HasShapelessTransDep.id -> m1.id,
+      m0HasScalazTransDep.id -> m1.id,
       m1.id -> m2.id,
       m1.id -> m3.id,
       m1.id -> m4.id,
@@ -53,9 +56,10 @@ trait Fixtures extends DependencyBuilders {
     )
   )
   val graphWithNestedShapelessWithoutEvicted = ModuleGraph(
-    nodes = Seq(m5, m4, m0HasShapelessTransDep, m1, m2, m0HasScalazDep),
+    nodes = Seq(m5, m4, m0HasShapelessTransDep, m0HasScalazTransDep, m1, m2, m0HasScalazDep),
     edges = Seq(
       m0HasShapelessTransDep.id -> m1.id,
+      m0HasScalazTransDep.id -> m1.id,
       m1.id -> m2.id,
       m1.id -> m4.id,
       m1.id -> m5.id,


### PR DESCRIPTION
…nsitive dependency violations

Re-do of https://github.com/Verizon/sbt-blockade/pull/3

The issue with that PR was builds would fail if they had a transitive dependency that was specified in a blacklist, even if the expiry date was not reached. This PR solves that by using the `Outcome` (along with an SBT setting flag) for transitive dependencies to determine if it should error out.

There are three tests introduced (one carried over from #3 ):

### unit tests
* makes sure `findTransitiveViolations` gives back all violations

### scripted tests
* `transitive-restricted-dependencies-fail-expired` tests that the build fails if a transitive dependency violates a blacklist item that has expired
* `transitive-restricted-dependencies-fail-notexpired` tests that the build succeeds if a transitive dependency only violates a not-expired blacklist item

This PR also changes the behavior of how transitive dependency violations are displayed - if `blockadeFailTransitive` is turned on then all violations are displayed, whereas if it is turned off it falls back to the "old" behavior which only displays one violation.