### PR TITLE
Adding URI resolver to allow for custom resolution

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
Adding a way to hook into URI resolution. The use case here is if you want to load the contents of a URI from a private source (like a non-public S3 bucket) you can bypass the default URI resolution and provide your own.  This can be useful for internal companies who want to leverage blockade