### PR TITLE
Cross-compile for SBT 1.0. Closes #10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.10.5
+  - 2.12.6
 
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,17 @@
+import sbt.Keys._
+import sbt._
 
 organization := "io.verizon.build"
 
 name := "sbt-blockade"
 
-scalacOptions ++= Seq("-deprecation", "-feature")
+scalaVersion := "2.12.6"
+
+sbtVersion in Global := "1.1.6"
+
+scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 
 sbtPlugin := true
-
-ScriptedPlugin.scriptedSettings
 
 scriptedLaunchOpts ++= Seq(
   "-Xmx1024M",
@@ -42,6 +46,8 @@ sonatypeProfileName := "io.verizon"
 
 pomPostProcess := { identity }
 
-libraryDependencies += "net.liftweb"   %% "lift-json" % "2.5.1"
+libraryDependencies += "net.liftweb" %% "lift-json" % "3.2.0"
+
+enablePlugins(ScalaTestPlugin)
 
 addCommandAlias("validate", ";test;scripted")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,4 @@
 
-libraryDependencies <+= (sbtVersion) { sv =>
-  "org.scala-sbt" % "scripted-plugin" % sv
-}
+libraryDependencies += { "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value }
 
-addSbtPlugin("io.verizon.build" % "sbt-rig" % "1.1.20")
+addSbtPlugin("io.verizon.build" % "sbt-rig" % "5.0.39")

--- a/src/main/scala/verizon/build/blockade.scala
+++ b/src/main/scala/verizon/build/blockade.scala
@@ -16,24 +16,17 @@
 //: ----------------------------------------------------------------------------
 package verizon.build
 
-import org.apache.ivy.plugins.version.VersionRangeMatcher
+import java.text.SimpleDateFormat
+import java.util.Date
+import net.liftweb.json._
 import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.apache.ivy.plugins.latest.LatestRevisionStrategy
-
-import java.io.File
-import java.net.URL
-import java.util.Date
-import scala.io.Source
-import java.text.SimpleDateFormat
-import scala.language.reflectiveCalls
-import sbinary.{Format, DefaultProtocol}
-import scala.util.{Try, Failure, Success}
-import scala.Console.{CYAN, RED, YELLOW, GREEN, RESET}
-import scala.collection.mutable.{MultiMap, HashMap, Set}
-
+import org.apache.ivy.plugins.version.VersionRangeMatcher
 import sbt._
-import depgraph._
-import net.liftweb.json._
+import sbt.librarymanagement.ModuleFilter
+import verizon.build.depgraph._
+import scala.Console.{CYAN, RED, RESET, YELLOW}
+import scala.util.Try
 
 /**
  * Represents a collection of whitelist and blacklist constraints.
@@ -349,7 +342,7 @@ object BlockadeOps {
       so.distinct.map {
         case (Outcome.Restricted(m), msg) => RED + s"Restricted: ${m.toString}. $msg" + RESET
         case (Outcome.Deprecated(m), msg) => YELLOW + s"Deprecated: ${m.toString}. $msg" + RESET
-        case (o, m) => "Unkonwn input to blockade display."
+        case (_, _) => "Unkonwn input to blockade display."
       }.mkString("\n\t", ",\n\t", "")
   }
 

--- a/src/main/scala/verizon/build/blockadeio.scala
+++ b/src/main/scala/verizon/build/blockadeio.scala
@@ -16,10 +16,9 @@
 //: ----------------------------------------------------------------------------
 package verizon.build
 
-import scala.util.Try
 import java.net.URI
 import scala.io.Source
-import net.liftweb.json._
+import scala.util.Try
 
 object blockadeio {
   type JsonAsString = String

--- a/src/main/scala/verizon/build/depgraph.scala
+++ b/src/main/scala/verizon/build/depgraph.scala
@@ -8,11 +8,10 @@ package verizon.build
 
 object depgraph {
 
-  import sbt._
-  import scala.language.reflectiveCalls
   import java.io.File
-  import scala.collection.mutable.{MultiMap, HashMap, Set}
-  import sbinary.{Format, DefaultProtocol}
+  import sbt._
+  import scala.collection.mutable.{HashMap, MultiMap, Set}
+  import scala.language.reflectiveCalls
 
   object SbtUpdateReport {
 

--- a/src/sbt-test/blockade/no-dependencies/project/plugins.sbt
+++ b/src/sbt-test/blockade/no-dependencies/project/plugins.sbt
@@ -3,5 +3,5 @@
   if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
                                   |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-  else addSbtPlugin("io.verizon.build" % "sbt-blockade" % pluginVersion)
+  else addSbtPlugin("io.verizon.build" % "sbt-blockade" % pluginVersion changing())
 }

--- a/src/sbt-test/blockade/no-dependencies/test
+++ b/src/sbt-test/blockade/no-dependencies/test
@@ -1,3 +1,5 @@
+> clean
+
 # blockade the dependencies and get blockaded
 > blockade
 

--- a/src/sbt-test/blockade/restricted-dependencies/test
+++ b/src/sbt-test/blockade/restricted-dependencies/test
@@ -1,1 +1,3 @@
+> clean
+
 -> blockade

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/test
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-expired/test
@@ -1,1 +1,2 @@
+> clean
 -> blockade

--- a/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/test
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies-fail-notexpired/test
@@ -1,1 +1,2 @@
+> clean
 > blockade

--- a/src/sbt-test/blockade/transitive-restricted-dependencies/test
+++ b/src/sbt-test/blockade/transitive-restricted-dependencies/test
@@ -1,1 +1,2 @@
+> clean
 > blockade

--- a/src/test/scala/verizon/build/BlockadeSpec.scala
+++ b/src/test/scala/verizon/build/BlockadeSpec.scala
@@ -1,16 +1,15 @@
 package verizon.build
 
-import org.scalatest.{FlatSpec, FreeSpec, Matchers, MustMatchers}
-
-import scala.util.{Failure, Success, Try}
-import sbt.ModuleID
 import java.text.SimpleDateFormat
 import java.util.Date
+import org.scalatest.{FreeSpec, MustMatchers}
+import sbt.ModuleID
+import scala.util.{Failure, Success}
 
 class BlockadeSpec extends FreeSpec with MustMatchers {
 
-  import Fixtures._
   import BlockadeOps._
+  import Fixtures._
 
   def df = new SimpleDateFormat("yyyy-MM-dd kk:mm:ss")
 
@@ -38,9 +37,8 @@ class BlockadeSpec extends FreeSpec with MustMatchers {
   "module restriction and deprecation" - {
     "whitelisting" - {
       "inside of acceptable range is allowed" in {
-        val `scalaz-7.1.5` = "org.scalaz" %% "scalaz-core" % "7.1.5"
         check(
-          defined = Seq(`scalaz-7.1.5`),
+          defined = Seq(`scalaz-core-7.1.5`),
           expected = Seq()) {
           s"""
              |{
@@ -57,10 +55,9 @@ class BlockadeSpec extends FreeSpec with MustMatchers {
         }
       }
      "lower than acceptable range is restricted" in {
-       val `scalaz-7.0.4` = "org.scalaz" %% "scalaz-core" % "7.0.4"
        check(
-         defined = Seq(`scalaz-7.0.4`),
-         expected = Seq(Outcome.Restricted(`scalaz-7.0.4`))) {
+         defined = Seq(`scalaz-core-7.0.4`),
+         expected = Seq(Outcome.Restricted(`scalaz-core-7.0.4`))) {
          s"""
             |{
             |  "whitelist": [
@@ -77,10 +74,9 @@ class BlockadeSpec extends FreeSpec with MustMatchers {
      }
 
       "higher than acceptable range is restricted" in {
-        val `scalaz-7.2.0` = "org.scalaz" %% "scalaz-core" % "7.2.0"
         check(
-          defined = Seq(`scalaz-7.2.0`),
-          expected = Seq(Outcome.Restricted(`scalaz-7.2.0`))) {
+          defined = Seq(`scalaz-core-7.2.0`),
+          expected = Seq(Outcome.Restricted(`scalaz-core-7.2.0`))) {
           s"""
              |{
              |  "whitelist": [

--- a/src/test/scala/verizon/build/Fixtures.scala
+++ b/src/test/scala/verizon/build/Fixtures.scala
@@ -1,12 +1,12 @@
 package verizon.build
 
-import sbt.impl.DependencyBuilders
+import sbt._
 import java.net.URL
 import depgraph._
 import BlockadeOps._
 
 object Fixtures extends Fixtures
-trait Fixtures extends DependencyBuilders {
+trait Fixtures {
   def load(p: String): URL =
     getClass.getClassLoader.getResource(p)
 
@@ -28,6 +28,9 @@ trait Fixtures extends DependencyBuilders {
   val `toplevel-has-trans-dep-on-scalaz` = "org.foo" %% "has-trans-dep-on-scalaz" % "1.2.5"
   val `doobie-core-0.2.3` = "org.tpolecat" %% "doobie-core" % "0.2.3"
   val `scalaz-core-7.1.4` = "org.scalaz" %% "scalaz-core" % "7.1.4"
+  val `scalaz-core-7.1.5` = "org.scalaz" %% "scalaz-core" % "7.1.5"
+  val `scalaz-core-7.0.4` = "org.scalaz" %% "scalaz-core" % "7.0.4"
+  val `scalaz-core-7.2.0` = "org.scalaz" %% "scalaz-core" % "7.2.0"
   val `scalaz-effect-7.1.4` = "org.scalaz" %% "scalaz-effect" % "7.1.4"
   val `scalaz-stream-0.8` = "org.scalaz.stream" %% "scalaz-stream" % "0.8"
   val `shapeless-2.2.5` = "com.chuusai" %% "shapeless" % "2.2.5"

--- a/src/test/scala/verizon/build/RecursiveBlockadeSpec.scala
+++ b/src/test/scala/verizon/build/RecursiveBlockadeSpec.scala
@@ -1,10 +1,11 @@
 package verizon.build
 
 import org.scalatest._
-import Fixtures._
-import BlockadeOps._
-import depgraph._
-import sbt._
+import sbt.ModuleID
+import sbt.librarymanagement.ModuleFilter
+import verizon.build.BlockadeOps._
+import verizon.build.Fixtures._
+import verizon.build.depgraph._
 
 class RecursiveBlockadeSpec extends FreeSpec with MustMatchers {
 


### PR DESCRIPTION
Implements cross-compilation for SBT 1.x line while still supporting the 0.13.x line. Closes #10 

A few notes on the chosen path here:
* In order to attempt to reduce the amount of changes here, I opted to copy `plugin.scala` and `blockade.scala` to a separate `scala-2.12` folder. The reason for this is because of SBT's modularization - for most classes, we're still able to reference via `sbt.{XYZ}`, there are however a few exceptions:
  * `ModuleFilter` is not exposed in this manner in SBT 1.x and thus we have to include `sbt.librarymanagement`. `ModuleFilter` is a large part of `blockade.scala`, so I opted to just copy the file for both `scala-2.10` and `scala-2.12` with only the namespace changed. Of course, this kind of stinks, since the implementation is now split, but it saves the initial headache of ripping up this huge file to extract commonalities 
  * For SBT 1.x, some minor changes had to be made to `plugin.scala` to implement the `blockade` task. Specifically, running `moduleGraphSbtTask.value` inside of a task now throws an error due to macro changes in the SBT 1.x line. The `blockade` task needs to be redefined as a `taskDyn`. **This might be an OK change to backport to the 0.13.x line implementation**
* I had to disable `fork := true` due to a serialization backwards incompatibility in the `ForkConfiguration` class from SBT. When `fork := true` is set, running scalatest with SBT 1.0 fails with this error: 
```
[error] Uncaught exception when running tests: java.io.InvalidClassException: sbt.ForkConfiguration; local class incompatible: 
stream classdesc serialVersionUID = -4842665101791919492, local class serialVersionUID = 7284856321565673083
```
* `scripted` tests now run `clean` before each script in order to ensure that `^scripted` (cross plugin compilation) works.

I would love some feedback/suggestions here on anyway to improve this implementation. Our company uses Blockade (and we love it!) and it's the last plugin we need compiled for SBT 1.x before we can make the company-wide switch!
